### PR TITLE
Passive weapon script to make making them easier

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -858,8 +858,8 @@ Generally these will be for passive weapons only but could in theory be non pass
 
 Passive weapons should be declared the same as other weapons. The GetSkillEffect method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
 
-Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is GetPassiveSkillEffect_<hookName>(...). For example, for a postEnvironmentHook the function called would be GetPassiveSkillEffect_PostEnvironmentHook(...).
+Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is GetPassiveSkillEffect_\<hookName\>(...). For example, for a postEnvironmentHook the function called would be GetPassiveSkillEffect_PostEnvironmentHook(...).
 
-The GetPassiveSkillEffect_<hookName>(...) function of the passed in weapon will be called each time the specified hook is fired if and only if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect_<hookName> functions can use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). If any data needs to persist, it should be stored in the GAME table.
+The GetPassiveSkillEffect_\<hookName\>(...) function of the passed in weapon will be called each time the specified hook is fired if and only if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect_\<hookName\> functions can use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). If any data needs to persist, it should be stored in the GAME table.
 
 This should support all hooks in the ModLoader and the ModUtil.

--- a/docs.md
+++ b/docs.md
@@ -807,9 +807,9 @@ Always returns `false` when called outside of `GetSkillEffect`.
 
 | Argument name | Type | Description |
 |---------------|------|-------------|
-| `weaponBaseName` | String | The base name for the weapon (i.e. without any _A, _B, or _AB) |
+| `weaponBaseName` | String | The base name for the weapon (i.e. without any "_A", "_B", or "_AB") |
 
-Returns a table containing all the full names of the passed weapon that are defined in the game files. If a particular weapon only has the _A updgrade then this will return only the base name and the basename with the "_A" suffix.
+Returns a table containing all the full names of the passed weapon that are defined in the game files. If a particular weapon only has the first updgrade then this will return a table with only the base name and the basename with the "_A" suffix in it.
 
 
 ### `weapon:getUpgradeSuffix`
@@ -850,7 +850,7 @@ Functions useful for creating passive weapons
 |---------------|------|-------------|
 | `weapon` | String | Base name of the weapon to add a passive effect to (i.e. without any upgrade suffixes) |
 | `hook` | String or table of Strings | The hooks that the GetPassiveSkillEffect() function should be triggered on. Defaults to "postEnvironmentHook" |
-| `weaponIsNotPassiveOnly` | boolean | "false" if the passed weapon should be forced to be passive (saves the modder some work). "true" if it should not be (allows for non-passive weapons to have passive effects). Defaults to "false" |
+| `weaponIsNotPassiveOnly` | boolean | "false" if the passed weapon should be forced to be passive (saves the modder some headache). "true" if it should not be (allows for non-passive weapons to have passive effects). Defaults to "false" |
 
 Adds the passive effect to the game. 
 
@@ -858,6 +858,6 @@ Generally these will be for passive weapons only but could in theory be non pass
 
 Passive weapons should be declared the same as other weapons. The GetSkillEffect method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
 
-The GetPassiveSkillEffect(...) function of the passed in weapon will be called each time the specified hook(s) are fired if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect function can use all the fields of the weapon via "self" and will be passed the arguements of whatever hook is specified. Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). The name of the hook that was fired is stored in "self.HookName" if different logic is required for different hooks. 
+The GetPassiveSkillEffect(...) function of the passed in weapon will be called each time the specified hook(s) are fired if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect function can use all the fields of the weapon via "self" and will be passed the arguements of whatever hook fires it. Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). The name of the hook that was fired is stored in "self.HookName" if different logic is required for different hooks. If any data needs to persist, it should be stored in the GAME table.
 
 This should support all hooks in the ModLoader and the ModUtil.

--- a/docs.md
+++ b/docs.md
@@ -849,17 +849,17 @@ Functions useful for creating passive weapons
 | Argument name | Type | Description |
 |---------------|------|-------------|
 | `weapon` | String | Base name of the weapon to add a passive effect to (i.e. without any upgrade suffixes) |
-| `hook` | String or table of Strings | The hooks that the GetPassiveSkillEffect() function should be triggered on. Defaults to "postEnvironmentHook" |
-| `weaponIsNotPassiveOnly` | boolean | "false" if the passed weapon should be forced to be passive (saves the modder some headache). "true" if it should not be (allows for non-passive weapons to have passive effects). Defaults to "false" |
+| `hook` | String or table of Strings | The hooks that the `GetPassiveSkillEffect()` function should be triggered on. Defaults to `postEnvironmentHook` |
+| `weaponIsNotPassiveOnly` | boolean | `false` if the passed weapon should be forced to be passive (saves the modder some headache). `true` if it should not be (allows for non-passive weapons to have passive effects). Defaults to `false` |
 
 Adds the passive effect to the game. 
 
 Generally these will be for passive weapons only but could in theory be non passive weapons as well. 
 
-Passive weapons should be declared the same as other weapons. The GetSkillEffect method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
+Passive weapons should be declared the same as other weapons. The `GetSkillEffect` method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
 
-Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is GetPassiveSkillEffect_\<hookName\>(...). For example, for a postEnvironmentHook the function called would be GetPassiveSkillEffect_PostEnvironmentHook(...).
+Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is `GetPassiveSkillEffect_<hookName>(...)`. For example, for a `postEnvironmentHook` the function called would be `GetPassiveSkillEffect_PostEnvironmentHook(...)`. Each passive effect function of the passed in weapon will be called each time the respective hook is fired if and only if a mech has the weapon equiped and it is powered on. 
 
-The GetPassiveSkillEffect_\<hookName\>(...) function of the passed in weapon will be called each time the specified hook is fired if and only if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect_\<hookName\> functions can use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). If any data needs to persist, it should be stored in the GAME table.
+All the arguements for the hooks are passed into the `GetPassiveSkillEffect_<hookName>` function. The passive effect functions can also use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in `GetSkillEffect()`. If any data needs to persist, it should be stored in the `GAME` table.
 
 This should support all hooks in the ModLoader and the ModUtil.

--- a/docs.md
+++ b/docs.md
@@ -42,6 +42,7 @@
 		* [getTileTable](#boardgettiletable)
 		* [getTileHealth](#boardgettilehealth)
 		* [getTileMaxHealth](#boardgettilemaxhealth)
+		* [getAllMechsTables](#boardgetallmechstables)
 	* [Dialog](#dialog) - TODO
 	* [Pawn](#pawn)
 		* [setFire](#pawnsetfire)
@@ -82,6 +83,12 @@
 	* [Weapon](#weapon)
 		* [plusTarget](#weaponplustarget)
 		* [isTipImage](#weaponistipimage)
+		* [getAllExistingNamesForWeapon](#weapongetallexistingnamesforweapon)
+		* [getUpgradeSuffix](#weapongetupgradesuffix)
+		* [getWeaponNameWithUpgrade](#weapongetweaponnamewithupgrade)
+		* [isWeaponPowered](#weaponisweaponpowered)
+	* [PassiveEffect](#passiveeffect)
+		* [addPassiveEffect](#passiveeffectaddpassiveeffect)
 
 
 ## Global
@@ -450,6 +457,13 @@ Returns the current health of the specified tile, or value of `getTileMaxHealth`
 
 Returns the max health of the specified tile, or 2 if the tile has no max health specified. This function uses save data, and will fail when used in test mech scenario.
 
+### `board:getAllMechsTables`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `sourceTable` | table | The table containing the mech data. If omitted the function will determine the table to use. Generally should be omitted |
+
+Returns a table containing the data for all mechs in the passed in table or the game board if omitted.
 
 ## Dialog
 
@@ -787,3 +801,63 @@ Returns a `PointList` containing points creating a plus-shaped targeting area.
 When called inside of a `GetSkillEffect`, returns `true` if the weapon is being called from inside of a tip image. `false` otherwise.
 
 Always returns `false` when called outside of `GetSkillEffect`.
+
+
+### `weapon:getAllExistingNamesForWeapon`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `weaponBaseName` | String | The base name for the weapon (i.e. without any _A, _B, or _AB) |
+
+Returns a table containing all the full names of the passed weapon that are defined in the game files. If a particular weapon only has the _A updgrade then this will return only the base name and the basename with the "_A" suffix.
+
+
+### `weapon:getUpgradeSuffix`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `wtable` | Table | Table containing the weapon's data |
+
+Returns a string containing the suffix corresponding to the weapon's current powered on status. I.e. if only the second upgrade is powered, it will return "_B". If no upgrade is powered it will return "".
+
+
+### `weapon:getWeaponNameWithUpgrade`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `weaponTable` | Table | Table containing the weapon's data |
+
+Returns a string containing the weapon's full name with the upgrade suffix based on the weapon's currently powered upgrades
+
+
+### `weapon:isWeaponPowered`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `weaponTable` | Table | Table containing the weapon's data |
+
+Returns true if the weapon either is always active (requires no power) or is currently powered on.
+
+
+## PassiveEffect
+
+Functions useful for creating passive weapons
+
+
+### `passiveEffect:addPassiveEffect`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `weapon` | String | Base name of the weapon to add a passive effect to (i.e. without any upgrade suffixes) |
+| `hook` | String or table of Strings | The hooks that the GetPassiveSkillEffect() function should be triggered on. Defaults to "postEnvironmentHook" |
+| `weaponIsNotPassiveOnly` | boolean | "false" if the passed weapon should be forced to be passive (saves the modder some work). "true" if it should not be (allows for non-passive weapons to have passive effects). Defaults to "false" |
+
+Adds the passive effect to the game. 
+
+Generally these will be for passive weapons only but could in theory be non passive weapons as well. 
+
+Passive weapons should be declared the same as other weapons. The GetSkillEffect method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
+
+The GetPassiveSkillEffect(...) function of the passed in weapon will be called each time the specified hook(s) are fired if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect function can use all the fields of the weapon via "self" and will be passed the arguements of whatever hook is specified. Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). The name of the hook that was fired is stored in "self.HookName" if different logic is required for different hooks. 
+
+This should support all hooks in the ModLoader and the ModUtil.

--- a/docs.md
+++ b/docs.md
@@ -44,6 +44,8 @@
 		* [getTileMaxHealth](#boardgettilemaxhealth)
 		* [getAllMechsTables](#boardgetallmechstables)
 	* [Dialog](#dialog) - TODO
+	* [PassiveEffect](#passiveeffect)
+		* [addPassiveEffect](#passiveeffectaddpassiveeffect)
 	* [Pawn](#pawn)
 		* [setFire](#pawnsetfire)
 		* [safeDamage](#pawnsafedamage)
@@ -87,8 +89,6 @@
 		* [getUpgradeSuffix](#weapongetupgradesuffix)
 		* [getWeaponNameWithUpgrade](#weapongetweaponnamewithupgrade)
 		* [isWeaponPowered](#weaponisweaponpowered)
-	* [PassiveEffect](#passiveeffect)
-		* [addPassiveEffect](#passiveeffectaddpassiveeffect)
 
 
 ## Global
@@ -472,6 +472,32 @@ System for dialogs with pawn cast rules, accessible via `modApiExt.dialog`.
 TODO
 
 
+## PassiveEffect
+
+Functions useful for creating passive weapons
+
+
+### `passiveEffect:addPassiveEffect`
+
+| Argument name | Type | Description |
+|---------------|------|-------------|
+| `weapon` | String | Base name of the weapon to add a passive effect to (i.e. without any upgrade suffixes) |
+| `hook` | String or table of Strings | The hooks that the `GetPassiveSkillEffect()` function should be triggered on. Defaults to `postEnvironmentHook` |
+| `weaponIsNotPassiveOnly` | boolean | `false` if the passed weapon should be forced to be passive (saves the modder some headache). `true` if it should not be (allows for non-passive weapons to have passive effects). Defaults to `false` |
+
+Adds the passive effect to the game. 
+
+Generally these will be for passive weapons only but could in theory be non passive weapons as well. 
+
+Passive weapons should be declared the same as other weapons. The `GetSkillEffect` method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
+
+Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is `GetPassiveSkillEffect_<hookName>(...)`. For example, for a `postEnvironmentHook` the function called would be `GetPassiveSkillEffect_PostEnvironmentHook(...)`. Each passive effect function of the passed in weapon will be called each time the respective hook is fired if and only if a mech has the weapon equiped and it is powered on. 
+
+All the arguements for the hooks are passed into the `GetPassiveSkillEffect_<hookName>` function. The passive effect functions can also use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in `GetSkillEffect()`. If any data needs to persist, it should be stored in the `GAME` table.
+
+This function should support all hooks in the ModLoader and the ModUtil.
+
+
 ## Pawn
 
 Functions useful when manipulating pawns, accessible via `modApiExt.pawn`.
@@ -837,29 +863,3 @@ Returns a string containing the weapon's full name with the upgrade suffix based
 | `weaponTable` | Table | Table containing the weapon's data |
 
 Returns true if the weapon either is always active (requires no power) or is currently powered on.
-
-
-## PassiveEffect
-
-Functions useful for creating passive weapons
-
-
-### `passiveEffect:addPassiveEffect`
-
-| Argument name | Type | Description |
-|---------------|------|-------------|
-| `weapon` | String | Base name of the weapon to add a passive effect to (i.e. without any upgrade suffixes) |
-| `hook` | String or table of Strings | The hooks that the `GetPassiveSkillEffect()` function should be triggered on. Defaults to `postEnvironmentHook` |
-| `weaponIsNotPassiveOnly` | boolean | `false` if the passed weapon should be forced to be passive (saves the modder some headache). `true` if it should not be (allows for non-passive weapons to have passive effects). Defaults to `false` |
-
-Adds the passive effect to the game. 
-
-Generally these will be for passive weapons only but could in theory be non passive weapons as well. 
-
-Passive weapons should be declared the same as other weapons. The `GetSkillEffect` method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
-
-Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is `GetPassiveSkillEffect_<hookName>(...)`. For example, for a `postEnvironmentHook` the function called would be `GetPassiveSkillEffect_PostEnvironmentHook(...)`. Each passive effect function of the passed in weapon will be called each time the respective hook is fired if and only if a mech has the weapon equiped and it is powered on. 
-
-All the arguements for the hooks are passed into the `GetPassiveSkillEffect_<hookName>` function. The passive effect functions can also use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in `GetSkillEffect()`. If any data needs to persist, it should be stored in the `GAME` table.
-
-This should support all hooks in the ModLoader and the ModUtil.

--- a/docs.md
+++ b/docs.md
@@ -858,6 +858,8 @@ Generally these will be for passive weapons only but could in theory be non pass
 
 Passive weapons should be declared the same as other weapons. The GetSkillEffect method that is generally used for weapons is only used to construct the tool tip for passive only weapons.
 
-The GetPassiveSkillEffect(...) function of the passed in weapon will be called each time the specified hook(s) are fired if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect function can use all the fields of the weapon via "self" and will be passed the arguements of whatever hook fires it. Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). The name of the hook that was fired is stored in "self.HookName" if different logic is required for different hooks. If any data needs to persist, it should be stored in the GAME table.
+Each hook passed into the function will call a different function in the passed weapon. The format for the function that is called for a given hook is GetPassiveSkillEffect_<hookName>(...). For example, for a postEnvironmentHook the function called would be GetPassiveSkillEffect_PostEnvironmentHook(...).
+
+The GetPassiveSkillEffect_<hookName>(...) function of the passed in weapon will be called each time the specified hook is fired if and only if a mech has the weapon equiped and it is powered on. The GetPassiveSkillEffect_<hookName> functions can use all the fields of the weapon via "self". Additionally, "Pawn" will be set to be the pawn who owns the weapon with the passive effect similar to how it is done in GetSkillEffect(). If any data needs to persist, it should be stored in the GAME table.
 
 This should support all hooks in the ModLoader and the ModUtil.

--- a/modApiExt/board.lua
+++ b/modApiExt/board.lua
@@ -228,6 +228,39 @@ local function updateShieldedStatus(damageList)
 	return dlist
 end
 
+--returns all the player mechs in the passed source table. If the table
+--is omitted it will determine the table to use.
+--This is a modified version of the pawn:getSavedataTable() function
+function board:getAllMechsTables(sourceTable)
+	mechsData = {}
+	if sourceTable then
+		--look through each item in the table for mechs
+		for k, v in pairs(sourceTable) do
+			--player mechs keys start with pawn and have the mech flag set to true
+			if type(v) == "table" and v.mech and modApi:stringStartsWith(k, "pawn") then
+				mechsData[#mechsData+1] = v
+			end
+		end	
+		
+		--if we found some mechs then return their data
+		if #mechsData > 0 then
+			return mechsData
+		end
+	else
+		--determine what table to use and call ourselves with that one
+		local region = self:getCurrentRegion()
+		local ptable = self:getAllMechsTables(SquadData)
+		if not ptable and region then
+			ptable = self:getAllMechsTables(region.player.map_data)
+		end
+
+		return ptable
+	end
+
+	--if we didn't find any mechs return nil
+	return nil
+end
+
 board.__init = function(self)
 --[[
 	-- shield detection is WIP

--- a/modApiExt/internal.lua
+++ b/modApiExt/internal.lua
@@ -223,11 +223,11 @@ function internal:createDialogTables(tbl)
 	self:createIfMissing(tbl.ruledDialogs, "PawnDeselected")
 end
 
-function internal:initPassiveWeaponData(tbl)
-	tbl.passiveWeaponData = {}
-	tbl.passiveWeaponData.possibleEffects = {}
-	tbl.passiveWeaponData.activeEffects = {}
-	tbl.passiveWeaponData.autoPassivedWeapons = {}
+function internal:initPassiveEffectData(tbl)
+	tbl.passiveEffectData = {}
+	tbl.passiveEffectData.possibleEffects = {}
+	tbl.passiveEffectData.activeEffects = {}
+	tbl.passiveEffectData.autoPassivedWeapons = {}
 end
 
 function internal:initCompat(tbl)
@@ -295,7 +295,7 @@ function internal:init(extObj)
 
 		self:initBroadcastHooks(m)
 		
-		self:initPassiveWeaponData(m)
+		self:initPassiveEffectData(m)
 
 		m.drawHook = sdl.drawHook(function(screen)
 			if not Game then

--- a/modApiExt/internal.lua
+++ b/modApiExt/internal.lua
@@ -223,6 +223,13 @@ function internal:createDialogTables(tbl)
 	self:createIfMissing(tbl.ruledDialogs, "PawnDeselected")
 end
 
+function internal:initPassiveWeaponData(tbl)
+	tbl.passiveWeaponData = {}
+	tbl.passiveWeaponData.possibleEffects = {}
+	tbl.passiveWeaponData.activeEffects = {}
+	tbl.passiveWeaponData.autoPassivedWeapons = {}
+end
+
 function internal:initCompat(tbl)
 	tbl.timer = modApi.timer
 end
@@ -287,6 +294,8 @@ function internal:init(extObj)
 		m.tipBoards = {}
 
 		self:initBroadcastHooks(m)
+		
+		self:initPassiveWeaponData(m)
 
 		m.drawHook = sdl.drawHook(function(screen)
 			if not Game then

--- a/modApiExt/modApiExt.lua
+++ b/modApiExt/modApiExt.lua
@@ -190,7 +190,7 @@ function modApiExt:load(mod, options, version)
 				modApiExt_internal.fireMostRecentResolvedHooks()
 			end
 			
-
+			self.passiveEffect:autoSetWeaponsPassiveFields()
 			self.passiveEffect:addHooks()
 		end
 	end)

--- a/modApiExt/modApiExt.lua
+++ b/modApiExt/modApiExt.lua
@@ -189,10 +189,11 @@ function modApiExt:load(mod, options, version)
 				modApiExt_internal.mostRecent = self
 				modApiExt_internal.fireMostRecentResolvedHooks()
 			end
+			
+
+			self.passiveWeapon:addHooks()
 		end
 	end)
-
-	self.passiveWeapon:load()
 	
 	self.loaded = true
 end

--- a/modApiExt/modApiExt.lua
+++ b/modApiExt/modApiExt.lua
@@ -113,12 +113,13 @@ function modApiExt:init(modulesDir)
 		self[k] = v
 	end
 
-	self.vector =   self:loadModule(self.modulesDir.."vector")
-	self.string =   self:loadModule(self.modulesDir.."string")
-	self.board =    self:loadModule(self.modulesDir.."board")
-	self.weapon =   self:loadModule(self.modulesDir.."weapon")
-	self.pawn =     self:loadModule(self.modulesDir.."pawn")
-	self.dialog =   self:loadModule(self.modulesDir.."dialog")
+	self.vector =        self:loadModule(self.modulesDir.."vector")
+	self.string =        self:loadModule(self.modulesDir.."string")
+	self.board =         self:loadModule(self.modulesDir.."board")
+	self.weapon =        self:loadModule(self.modulesDir.."weapon")
+	self.pawn =          self:loadModule(self.modulesDir.."pawn")
+	self.dialog =        self:loadModule(self.modulesDir.."dialog")
+	self.passiveWeapon = self:loadModule(self.modulesDir.."passiveWeapon")
 
 	return self
 end
@@ -191,6 +192,8 @@ function modApiExt:load(mod, options, version)
 		end
 	end)
 
+	self.passiveWeapon:load()
+	
 	self.loaded = true
 end
 

--- a/modApiExt/modApiExt.lua
+++ b/modApiExt/modApiExt.lua
@@ -119,7 +119,7 @@ function modApiExt:init(modulesDir)
 	self.weapon =        self:loadModule(self.modulesDir.."weapon")
 	self.pawn =          self:loadModule(self.modulesDir.."pawn")
 	self.dialog =        self:loadModule(self.modulesDir.."dialog")
-	self.passiveWeapon = self:loadModule(self.modulesDir.."passiveWeapon")
+	self.passiveEffect = self:loadModule(self.modulesDir.."passiveEffect")
 
 	return self
 end
@@ -191,7 +191,7 @@ function modApiExt:load(mod, options, version)
 			end
 			
 
-			self.passiveWeapon:addHooks()
+			self.passiveEffect:addHooks()
 		end
 	end)
 	

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -177,15 +177,19 @@ end
 --passive effects
 function buildPassiveEffectHookFn(hook)
 	return function(...)
-		if addPassiveEffectDebug then LOG("Evaluating active(powered) passive effects for hook: "..hook) end
-		local previousPawn = Pawn
-		if modApiExt_internal.passiveEffectData.activeEffects[hook] then
-			for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
-				Pawn = Board:GetPawn(effectWeaponTable.pawnId)
-				effectWeaponTable.effect(effectWeaponTable.weapon, ...)
+		if not passiveEffect.weapon:isTipImage() then
+			if addPassiveEffectDebug then LOG("Evaluating active(powered) passive effects for hook: "..hook) end
+			local previousPawn = Pawn
+			if modApiExt_internal.passiveEffectData.activeEffects[hook] then
+				for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
+					Pawn = Board:GetPawn(effectWeaponTable.pawnId)
+					effectWeaponTable.effect(effectWeaponTable.weapon, ...)
+				end
 			end
+			Pawn = previousPawn
+		else
+			if addPassiveEffectDebug then LOG("Detected this is for a tool tip. Skipping active(powered) passive effects for hook: "..hook) end
 		end
-		Pawn = previousPawn
 	end
 end
 

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -43,7 +43,7 @@ function passiveEffect:addPassiveEffect(weapon, hook, weaponIsNotPassiveOnly)
 	--if they pass a table, add it for each hook
 	if type(hook) == "table" then
 		for _,singleHook in pairs(hook) do
-			self:addPassiveEffect(weapon, singleHook)
+			self:addPassiveEffect(weapon, singleHook, weaponIsNotPassiveOnly)
 		end
 	else
 		hook = hook or "postEnvironmentHook" --default to Post environemnt since thats when most effects occur

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -163,7 +163,7 @@ end
 --passive effects
 function buildPassiveEffectHookFn(hook)
 	return function(...)
-		LOG("Evaluating "..#modApiExt_internal.passiveEffectData.activeEffects[hook].." active(powered) passive effects for hook: "..hook)
+		if addPassiveEffectDebug then LOG("Evaluating "..#modApiExt_internal.passiveEffectData.activeEffects[hook].." active(powered) passive effects for hook: "..hook) end
 		local previousPawn = Pawn
 		for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
 			Pawn = Board:GetPawn(effectWeaponTable.pawnId)

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -165,10 +165,12 @@ function buildPassiveEffectHookFn(hook)
 	return function(...)
 		if addPassiveEffectDebug then LOG("Evaluating "..#modApiExt_internal.passiveEffectData.activeEffects[hook].." active(powered) passive effects for hook: "..hook) end
 		local previousPawn = Pawn
-		for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
-			Pawn = Board:GetPawn(effectWeaponTable.pawnId)
-			effectWeaponTable.weapon.HookName = hook
-			effectWeaponTable.effect(effectWeaponTable.weapon, ...)
+		if modApiExt_internal.passiveEffectData.activeEffects[hook] then
+			for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
+				Pawn = Board:GetPawn(effectWeaponTable.pawnId)
+				effectWeaponTable.weapon.HookName = hook
+				effectWeaponTable.effect(effectWeaponTable.weapon, ...)
+			end
 		end
 		Pawn = previousPawn
 	end

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -120,7 +120,7 @@ function passiveEffect.determineIfPassivesAreActive(mission)
 	if addPassiveEffectDebug then LOG("Determining what Passive Effects are active(powered)...") end
 
 	--clear the previous list of active effects
-	modApiExt_internal.passiveEffectData.activeEffects = {}
+	passiveEffect.clearActivePassives(mission)
 	
 	--loop through the player mechs to see if they have one of the passive weapons equiped and powered
 	local mechsData = passiveEffect.board:getAllMechsTables()
@@ -145,6 +145,10 @@ function passiveEffect.determineIfPassivesAreActive(mission)
 	end
 end
 
+function passiveEffect.clearActivePassives(mission)
+	modApiExt_internal.passiveEffectData.activeEffects = {}
+end
+
 --Function that is called after the modUtils are loaded that will set the passive
 --field of any passive weapons automagically so the modder doesn't have to worry 
 --about remembering to do this
@@ -163,7 +167,7 @@ end
 --passive effects
 function buildPassiveEffectHookFn(hook)
 	return function(...)
-		if addPassiveEffectDebug then LOG("Evaluating "..#modApiExt_internal.passiveEffectData.activeEffects[hook].." active(powered) passive effects for hook: "..hook) end
+		if addPassiveEffectDebug then LOG("Evaluating active(powered) passive effects for hook: "..hook) end
 		local previousPawn = Pawn
 		if modApiExt_internal.passiveEffectData.activeEffects[hook] then
 			for _,effectWeaponTable in pairs(modApiExt_internal.passiveEffectData.activeEffects[hook]) do
@@ -184,6 +188,7 @@ function passiveEffect:addHooks()
 
 	modApi:addMissionStartHook(self.determineIfPassivesAreActive) --covers starting a new mission
 	modApi:addPostLoadGameHook(self.determineIfPassivesAreActive) --covers loading into (continuing) a mission
+	modApi:addMissionEndHook(self.clearActivePassives) --covers ending a mission (prevents tool tips from failing in overworld screen)
 	
 	--Create the needed hook objects and add the functions that handle executing
 	--the active passive effects

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -1,4 +1,4 @@
-local addPassiveEffectDebug = true --set this to true if you are having issues with running passive weapons to help determine what is going wrong
+local addPassiveEffectDebug = false --set this to true if you are having issues with running passive weapons to help determine what is going wrong
 local PW_EFFECT_FN_NAME = "GetPassiveSkillEffect" --shouldn't change this. Treat it as a constant. Changing in later version would cause incompatibility
 
 local passiveEffect = {}

--- a/modApiExt/passiveEffect.lua
+++ b/modApiExt/passiveEffect.lua
@@ -159,10 +159,10 @@ function passiveEffect.clearActivePassives(mission)
 	modApiExt_internal.passiveEffectData.activeEffects = {}
 end
 
---Function that is called after the modUtils are loaded that will set the passive
+--Function that is called after the mods are loaded that will set the passive
 --field of any passive weapons automagically so the modder doesn't have to worry 
 --about remembering to do this
-local function autoSetWeaponsPassiveFields()
+function passiveEffect:autoSetWeaponsPassiveFields()
 	for weapon,_ in pairs(modApiExt_internal.passiveEffectData.autoPassivedWeapons) do
 		if addPassiveEffectDebug then LOG("Making weapon "..weapon.." passive...") end
 		for _, variety in pairs(passiveEffect.weapon:getAllExistingNamesForWeapon(weapon)) do
@@ -196,9 +196,6 @@ end
 --The function that adds the required hooks to the game for passive weapons
 --This should only be called once for all instances of ModUtils!
 function passiveEffect:addHooks()
-	--the hook that is fired after modUtils have loaded
-	self:addMostRecentResolvedHook(autoSetWeaponsPassiveFields)
-
 	modApi:addMissionStartHook(self.determineIfPassivesAreActive) --covers starting a new mission
 	modApi:addPostLoadGameHook(self.determineIfPassivesAreActive) --covers loading into (continuing) a mission
 	modApi:addMissionEndHook(self.clearActivePassives) --covers ending a mission (prevents tool tips from failing in overworld screen)

--- a/modApiExt/passiveWeapon.lua
+++ b/modApiExt/passiveWeapon.lua
@@ -21,32 +21,37 @@ passiveWeapon.activeEffectsData = {}
 --defaults to addPostEnvironmentHook. This should support all hooks in the
 --ModLoader and the ModUtil.
 function passiveWeapon:addPassiveEffect(weapon, hook)
-	hook = hook or "PostEnvironmentHook"
-	
-	--ensure the hook is a valid function for a hook
-	--can be either the "add" version or the hook name itself
-	if addPassiveEffectDebug then LOG("Recieved hook name: "..hook) end
-	assert(type(hook) == "string")
-	
-	--ensure its uppercase and then add the "add" to the front
-	hook  = hook:gsub("^%l", string.upper)
-	hook = "add"..hook
-	if addPassiveEffectDebug then LOG("Created the string corresponding to the add function for the hook:"..hook) end
-	assert(self[hook] or modApi[hook])
-	
-	--ensure they are valid weapon/effect combo to reduce user error	
+	--ensure they are valid weapon/effect combo upfront to reduce user error	
+	assert(type(weapon) == "string")
 	assert(_G[weapon])
 	assert(_G[weapon][PW_EFFECT_FN_NAME])
-	
-	--get the list of potential effects associated with the hook or create it
-	local hookTable = self.possibleEffectsData[hook]
-	if not hookTable then
-		hookTable = {}
-		self.possibleEffectsData[hook] = hookTable
+		
+	if type(hook) == "table" then
+		for _,singleHook in pairs(hook) do
+			self:addPassiveEffect(weapon, singleHook)
+		end
+	else
+		hook = hook or "PostEnvironmentHook" --default to Post environemnt since thats when most effects occur
+		
+		--ensure the hook is a valid function for a hook
+		--can be either the "add" version or the hook name itself
+		assert(type(hook) == "string")
+		
+		--ensure its uppercase and then add the "add" to the front
+		hook = hook:gsub("^%l", string.upper)
+		hook = "add"..hook
+		assert(self[hook] or modApi[hook])
+		
+		--get the list of potential effects associated with the hook or create it
+		local hookTable = self.possibleEffectsData[hook]
+		if not hookTable then
+			hookTable = {}
+			self.possibleEffectsData[hook] = hookTable
+		end
+		
+		--add the weapon to the list of possible passive effects
+		table.insert(hookTable, weapon)
 	end
-	
-	--add the weapon to the list of possible passive effects
-	table.insert(hookTable, weapon)
 end
 
 --checks if the passed weapon data is in the list of potential passive weapons

--- a/modApiExt/passiveWeapon.lua
+++ b/modApiExt/passiveWeapon.lua
@@ -1,26 +1,29 @@
---set this to true if you are having issues with running passive weapons to help determine what is going wrong
-local addPassiveEffectDebug = true
-local PW_EFFECT_FN_NAME = "GetPassiveSkillEffect"
+local addPassiveEffectDebug = true --set this to true if you are having issues with running passive weapons to help determine what is going wrong
+local PW_EFFECT_FN_NAME = "GetPassiveSkillEffect" --shouldn't change this. Treat it as a constant. Changing in later version would cause incompatibility
 
 local passiveWeapon = {}
 
---creates a string for the add function corresponding to the passed hook
+--creates a string for the add function corresponding to the passed hook.
+--For now all the hook appear to follow the same format but any special cases
+--can be addressed in this function as needed
 local function getAddFunctionForHook(hook)
 	return "add"..hook:gsub("^%l", string.upper)
 end
 
---A function that adds the passive weapon to the game. The passive weapon
---should be declared the same as other weapons but should have the additional
---Passive field set to a string of the weapon name plus the extension 
---(_A, _B, _AB) if applicable. The GetSkillEffect method that is generally used
---for weapons will only be used to construct the tool tip animation. The method
---passed to this function will be called each time the passed hook is fired if
---a mech has the weapon equiped and it is powered on. The method passed as the
---passive effect can use all the fields of the weapon via the self field and 
---will be passed the arguements of whatever hook is specified. Additionally, 
---Pawn will be set to be the pawn who owns the weapon with the passive effect 
---similar to how it is done in GetSkillEffect() If the hook is omitted it 
---defaults to addPostEnvironmentHook. This should support all hooks in the
+--A function that adds the passive effect to the game. Generally these will 
+--be for passive weapons only but could in theory be non passive weapons 
+--as well. Passive weapons should be declared the same as other weapons. The 
+--GetSkillEffect method that is generally used for weapons is only used to 
+--construct the tool tip for passive only weapons. The GetPassiveSkillEffect(...)
+--function of the passed in weapon will be called each time the specified hook(s) 
+--are fired if a mech has the weapon equiped and it is powered on. The 
+--GetPassiveSkillEffect function can use all the fields of the weapon via 
+--"self" and will be passed the arguements of whatever hook is specified. 
+--Additionally, "Pawn" will be set to be the pawn who owns the weapon with 
+--the passive effect similar to how it is done in GetSkillEffect(). The 
+--name of the hook that was fired is stored in "self.HookName" if different 
+--logic is required for different hooks. If the hook is omitted it 
+--defaults to postEnvironmentHook. This should support all hooks in the
 --ModLoader and the ModUtil.
 function passiveWeapon:addPassiveEffect(weapon, hook, weaponIsNotPassiveOnly)
 	--ensure they are valid weapon/effect combo upfront to reduce user error	
@@ -155,10 +158,10 @@ local function autoSetWeaponsPassiveFields()
 	end
 end
 
---Function to generate the object to handle calling all passive effects registered 
---for a specific hook when the hook is fired which contains the function to be added
---to the hook. This should be called once per hook with possible passive effects
-function generatePassiveEffectHookFn(hook)
+--Generates the function that calls all passive effects registered for a specific 
+--hook when the hook is fired. This should be called once per hook with possible
+--passive effects
+function buildPassiveEffectHookFn(hook)
 	return function(...)
 		LOG("Evaluating "..#modApiExt_internal.passiveWeaponData.activeEffects[hook].." active(powered) passive effects for hook: "..hook)
 		local previousPawn = Pawn
@@ -171,6 +174,8 @@ function generatePassiveEffectHookFn(hook)
 	end
 end
 
+--The function that adds the required hooks to the game for passive weapons
+--This should only be called once for all instances of ModUtils!
 function passiveWeapon:addHooks()
 	--the hook that is fired after modUtils have loaded
 	self:addMostRecentResolvedHook(autoSetWeaponsPassiveFields)

--- a/modApiExt/passiveWeapon.lua
+++ b/modApiExt/passiveWeapon.lua
@@ -1,5 +1,5 @@
 --set this to true if you are having issues with running passive weapons to help determine what is going wrong
-local addPassiveEffectDebug = true
+local addPassiveEffectDebug = false
 
 local passiveWeapon = {}
 

--- a/modApiExt/passiveWeapon.lua
+++ b/modApiExt/passiveWeapon.lua
@@ -1,0 +1,186 @@
+--set this to true if you are having issues with running passive weapons to help determine what is going wrong
+local addPassiveEffectDebug = false
+
+local passiveWeapon = {}
+
+passiveWeapon.possibleEffectsData = {}
+passiveWeapon.activeEffectsData = {}
+passiveWeapon.selfModApiExt = {}
+
+--pulled from pawn(?) modUtil - remove
+local function getUpgradeSuffix(wtable)
+	if
+		wtable.upgrade1 and wtable.upgrade1[1] > 0 and
+		wtable.upgrade2 and wtable.upgrade2[1] > 0
+	then
+		return "_AB"
+	elseif wtable.upgrade1 and wtable.upgrade1[1] > 0 then
+		return "_A"
+	elseif wtable.upgrade2 and wtable.upgrade2[1] > 0 then
+		return "_B"
+	end
+
+	return ""
+end
+
+--useful wrapper function put in weapon
+local function getWeaponNameWithUpgrade(weaponTable)
+	return weaponTable.id..getUpgradeSuffix(weaponTable)
+end
+
+--useful function put in weapon
+local function isWeaponPowered(weaponTable)
+	--Check that all numbers are greater than 0
+	--I think you really only need to check the first but just to be safe I check them all
+	for _,power in pairs(weaponTable.power) do
+		if power <= 0 then
+			return false
+		end
+	end
+	
+	--empty means it needs no power so its always on!
+	return true
+end
+
+--Modification of the pawn:getData - put in board
+function passiveWeapon:getAllMechsTables(sourceTable)
+	mechsData = {}
+	if sourceTable then
+		for k, v in pairs(sourceTable) do
+			if type(v) == "table" and v.mech and modApi:stringStartsWith(k, "pawn") then
+				mechsData[#mechsData+1] = v
+			end
+		end	
+		
+		if #mechsData > 0 then
+			return mechsData
+		end
+	else
+		local region = self.selfModApiExt.board:getCurrentRegion()
+		local ptable = self:getAllMechsTables(SquadData)
+		if not ptable and region then
+			ptable = self:getAllMechsTables(region.player.map_data)
+		end
+
+		return ptable
+	end
+
+	return nil
+end
+
+function passiveWeapon:addPassiveWeapon(weapon, passiveEffect, hook)
+	hook = hook or "addPostEnvironmentHook"
+	assert(type(hook) == "string")
+	assert(modApi:stringStartsWith(hook, "add"))
+	assert(self.selfModApiExt[hook] or modApi[hook])
+	
+	assert(type(weapon) == "string")
+	assert(type(passiveEffect) == "string")
+	
+	--ensure they are valid weapon/effect combo
+	assert(_G[weapon])
+	assert(_G[weapon][passiveEffect])
+	
+	local hookTable = self.possibleEffectsData[hook]
+	if not hookTable then
+		hookTable = {}
+		passiveWeapon.possibleEffectsData[hook] = hookTable
+	end
+	
+	local data = {}
+	data.weapon = weapon
+	data.effect = passiveEffect
+	table.insert(hookTable, data)
+end
+
+function passiveWeapon.checkAndAddIfPassive(weaponTable)
+	--for each passive weapon registered, check the id and if it matched then add the effect to
+	--the list of effects to execute
+	for hook, possibleEffects in pairs(passiveWeapon.possibleEffectsData) do
+		if addPassiveEffectDebug then LOG("Checking passive weapons for hook: "..hook) end
+		for i, pEffectTable in pairs(possibleEffects) do
+			if addPassiveEffectDebug then LOG("Checking known passive weapon id: "..pEffectTable.weapon) end
+			if weaponTable.id == pEffectTable.weapon then
+				local wName = getWeaponNameWithUpgrade(weaponTable)
+				if addPassiveEffectDebug then LOG("FOUND PASSIVE WEAPON!: "..wName) end
+				local wObj = _G[wName]
+				local wEffect = wObj[pEffectTable.effect]
+				
+				if isWeaponPowered(weaponTable) then
+					if addPassiveEffectDebug then LOG("And it is active/powered") end
+					local hookTable = passiveWeapon.activeEffectsData[hook]
+					if not hookTable then
+						hookTable = {}
+						passiveWeapon.activeEffectsData[hook] = hookTable
+					end
+					
+					local data = {}
+					data.weapon = wObj
+					data.effect = wEffect
+					table.insert(hookTable, data)
+				elseif addPassiveEffectDebug then 
+					LOG("but it is not active(powered)...")
+				end
+			end
+		end
+	end
+end
+
+passiveWeapon.determineIfPassivesAreActive = function(mission)
+	if addPassiveEffectDebug then LOG("Determining what Passive Effects are active(powered)...") end
+
+	--clear the previous list
+	passiveWeapon.activeEffectsData = {}
+	
+	--loop through the player mechs to see if they have one of the passive weapons equiped and powered
+	local mechsData = passiveWeapon:getAllMechsTables()
+	for _, mechData in pairs(mechsData) do
+		if addPassiveEffectDebug then LOG("Checking mech: "..mechData.type) end
+		--get the mech's weapon data
+		local primary = passiveWeapon.selfModApiExt.pawn:getWeaponData(mechData, "primary")
+		local secondary = passiveWeapon.selfModApiExt.pawn:getWeaponData(mechData, "secondary")
+	
+		--if it has a primary then check if it is in the passive effects list
+		if primary.id then
+			if addPassiveEffectDebug then LOG("Checking primary weapon: "..primary.id) end
+			passiveWeapon.checkAndAddIfPassive(primary)
+		end
+		
+		--if it has a secondary then check if it is in the passive effects list
+		if secondary.id then
+			if addPassiveEffectDebug then LOG("Checking secondary weapon: "..secondary.id) end
+			passiveWeapon.checkAndAddIfPassive(secondary)
+		end
+	end
+end
+
+function passiveWeapon:load(modUtil)
+	self.selfModApiExt = modUtil
+	modApi:addMissionStartHook(self.determineIfPassivesAreActive)
+	modApi:addPostLoadGameHook(self.determineIfPassivesAreActive)
+	
+	--Add the needed hooks
+	for hook,_ in pairs(self.possibleEffectsData) do 
+		local fnString = 		"return function(...)\n"
+		if addPassiveEffectDebug then
+			fnString = fnString..	"\tLOG(\"Evaluating \"..#passiveWeapon.activeEffectsData[\""..hook.."\"]..\" active(powered)passive effects for hook: "..hook.."\")\n"
+		end
+		fnString = fnString..		"\tfor _,effectWeaponTable in pairs(passiveWeapon.activeEffectsData[\""..hook.."\"]) do\n"..
+										"\t\teffectWeaponTable.effect(effectWeaponTable.weapon, ...)\n"..
+									"\tend\n"..
+								"end"
+		if addPassiveEffectDebug then 
+			LOG("Creating passive effect for hook "..hook.." -\n"..fnString)
+		end
+		
+		local hookFn = loadstring(fnString)()
+		
+		if self.selfModApiExt[hook] then
+			self.selfModApiExt[hook](self.selfModApiExt, hookFn)
+		else --already asserted that its in one of the two
+			modApi[hook](modApi, hookFn)
+		end
+	end
+end
+		
+return passiveWeapon

--- a/modApiExt/pawn.lua
+++ b/modApiExt/pawn.lua
@@ -192,21 +192,6 @@ function pawn:getWeaponData(ptable, field)
 	return t
 end
 
-local function getUpgradeSuffix(wtable)
-	if
-		wtable.upgrade1 and wtable.upgrade1[1] > 0 and
-		wtable.upgrade2 and wtable.upgrade2[1] > 0
-	then
-		return "_AB"
-	elseif wtable.upgrade1 and wtable.upgrade1[1] > 0 then
-		return "_A"
-	elseif wtable.upgrade2 and wtable.upgrade2[1] > 0 then
-		return "_B"
-	end
-
-	return ""
-end
-
 function pawn:getWeapons(pawnId)
 	local ptable = self:getSavedataTable(pawnId)
 	local t = {}
@@ -215,10 +200,10 @@ function pawn:getWeapons(pawnId)
 	local secondary = self:getWeaponData(ptable, "secondary")
 
 	if primary.id then
-		t[1] = primary.id .. getUpgradeSuffix(primary)
+		t[1] = primary.id .. self.weapon:getUpgradeSuffix(primary)
 	end
 	if secondary.id then
-		t[2] = secondary.id .. getUpgradeSuffix(secondary)
+		t[2] = secondary.id .. self.weapon:getUpgradeSuffix(secondary)
 	end
 
 	return t

--- a/modApiExt/weapon.lua
+++ b/modApiExt/weapon.lua
@@ -22,6 +22,43 @@ function weapon:plusTarget(center, size)
 	return ret
 end
 
+--Returns the upgrade suffix of the weapon i.e. _A,_B,_AB, or empty
+function weapon:getUpgradeSuffix(wtable)
+	if
+		wtable.upgrade1 and wtable.upgrade1[1] > 0 and
+		wtable.upgrade2 and wtable.upgrade2[1] > 0
+	then
+		return "_AB"
+	elseif wtable.upgrade1 and wtable.upgrade1[1] > 0 then
+		return "_A"
+	elseif wtable.upgrade2 and wtable.upgrade2[1] > 0 then
+		return "_B"
+	end
+
+	return ""
+end
+
+--Returns the full name of the weapon including the suffix (_A,_B,_AB, or none)
+function weapon:getWeaponNameWithUpgrade(weaponTable)
+	return weaponTable.id..self:getUpgradeSuffix(weaponTable)
+end
+
+--Determines if the weapon is powered on. This will return true if the 
+--weapon is on by default (i.e. requires no power) or it is fully 
+--powered and false otherwise
+function weapon:isWeaponPowered(weaponTable)
+	--Check that all numbers are greater than 0
+	--I think you really only need to check the first but just to be safe I check them all
+	for _,power in pairs(weaponTable.power) do
+		if power <= 0 then
+			return false
+		end
+	end
+	
+	--empty means it needs no power so its always on!
+	return true
+end
+
 --[[
 	When called inside of GetSkillEffect(), returns true if the weapon is being
 	called from inside of a tip image. False otherwise.

--- a/modApiExt/weapon.lua
+++ b/modApiExt/weapon.lua
@@ -22,6 +22,18 @@ function weapon:plusTarget(center, size)
 	return ret
 end
 
+--Returns all the varieties of the past weapon name that are defined
+function weapon:getAllExistingNamesForWeapon(weaponBaseName)
+	local allExisting = {}
+	for _, possiblility in pairs({weaponBaseName, weaponBaseName.."_A", weaponBaseName.."_B", weaponBaseName.."_AB"}) do
+		if _G[possiblility] then
+			table.insert(allExisting, possiblility)
+		end
+	end
+	
+	return allExisting
+end
+
 --Returns the upgrade suffix of the weapon i.e. _A,_B,_AB, or empty
 function weapon:getUpgradeSuffix(wtable)
 	if


### PR DESCRIPTION
I was adding a passive weapon to my game which was more difficult than I expected so I decided to make it even harder on myself and make a script to make it easy.

The comment in the passiveWeapon.lua summarizes the script and functions well
"--A function that adds the passive weapon to the game. The passive weapon
--should be declared the same as other weapons but should have the additional
--Passive field set to a string of the weapon name plus the extension 
--(_A, _B, _AB) if applicable. The GetSkillEffect method that is generally used
--for weapons will only be used to construct the tool tip animation. The method
--passed to this function will be called each time the passed hook is fired if
--a mech has the weapon equiped and it is powered on. The method passed as the
--passive effect can use all the fields of the weapon via the self field and 
--will be passed the arguements of whatever hook is specified. If the hook is 
--omitted it defaults to addPostEnvironmentHook. This should support all hooks
--in the ModLoader and the ModUtil."

I'll add information and an example to the API if this gets pulled in too