### PR TITLE
Fix most false positives with the move undo hook firing wrongly

### DIFF
--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -70,11 +70,11 @@ function modApiExtHooks:trackAndUpdatePawns(mission)
 				if pd.undoPossible ~= undo then
 					-- Undo was possible in previous game update, but no longer is.
 					-- Positions are different, which means that the undo was *not*
-					-- disabled due to skill usage on a pawn -- swap skills
-					-- are not instant, so we wouldn't register change in *both*
-					-- undo state AND pawn position in a single update if that were
-					-- the case. So it has to be the 'undo move' option.
-					if pd.undoPossible and not undo and pd.loc ~= p then
+					-- disabled due to skill usage on a pawn as that would make the pawn inactive
+					-- while most skills are not instant, leap and dash skills are problematic
+					-- as undo state changes at the same time as a move
+					-- So it has to be the 'undo move' option.
+					if pd.undoPossible and not undo and pd.loc ~= p and pawn:IsActive() then
 						self.dialog:triggerRuledDialog("MoveUndo", { main = id })
 						modApiExt_internal.firePawnUndoMoveHooks(mission, pawn, pd.loc)
 					end


### PR DESCRIPTION
Before, the MoveUndo hook would fire after using leap mech or charge mech's attack as the pawn manages to move and mark undo as impossible in the same frame. This causes move abilities from Cauldron Pilots that only work once per turn to work multiple times if you use them right before a leap or a charge.

This fix ensures the pawn is active after undo becomes unavailable, as clicking undo move always leaves you with an active pawn. The one case of remaining active after using a weapon is with pawns such as Silica, though in that case undo move was not previously available. Arguably as part of this fix we could remove the space change check, but not sure if there is a case that covers that I missed.

This does not currently handle pilots such as Chen who can move after attacking, however this will fix all cases in Cauldron Pilots as you never both have a modded pilot skill and Chen. To fix the remaining edge case, we could swap `Pawn:IsActive` for `Pawn:IsMovementAvailable`, though that won't work in modloader 2.4.1 (requires the cutils pull request)