### PR TITLE
Fix nested GetSkillEffect calls not working

### DIFF
--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -480,15 +480,15 @@ local function isSkill(v)
 end
 
 local function isSkillProxy(v)
-	if type(v) == "table" and v.id ~= nil then
+	if type(v) == "table" and v.__skill ~= nil then
 		local mt = getmetatable(v)
-		return mt ~= nil and mt.__index = skillProxyIndexFn
+		return mt ~= nil and mt.__index == skillProxyIndexFn
 	end
 	return false
 end
 
 local function skillProxyIndexFn(tbl, key)
-	local realSkill = modApiExt_internal.oldSkills[tbl.id]
+	local realSkill = tbl.__skill
 	if key == "GetSkillEffect" then
 		if modApiExt_internal.nestedCall_GetSkillEffect then
 			return realSkill.GetSkillEffect
@@ -500,8 +500,7 @@ local function skillProxyIndexFn(tbl, key)
 end
 
 local function skillProxyNewIndexFn(tbl, key, value)
-	local realSkill = modApiExt_internal.oldSkills[tbl.id]
-	realSkill[key] = value
+	tbl.__skill[key] = value
 end
 
 function modApiExt_internal.createSkillProxy(skillTable)
@@ -509,7 +508,9 @@ function modApiExt_internal.createSkillProxy(skillTable)
 	modApiExt_internal.oldSkills[skillTable.__Id] = skillTable
 
 	local skillProxy = setmetatable(
-		{ id = skillTable.__Id },
+		{
+			__skill = skillTable,
+		},
 		{
 			__index = skillProxyIndexFn,
 			__newindex = skillProxyNewIndexFn

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -398,9 +398,9 @@ local function modApiExtGetSkillEffect(self, p1, p2, ...)
 
 	local prevEnv = getfenv(1)
 	local fn = skillIndex[self.__Id].GetSkillEffect
-	setfenv(1, skillIndex)
+	setfenv(fn, skillIndex)
 	local skillFx = fn(self, p1, p2, ...)
-	setfenv(1, prevEnv)
+	setfenv(fn, prevEnv)
 
 	if not Pawn then
 		-- PAWN is missing, this happens when loading into a game

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -481,6 +481,15 @@ local function isSkill(v)
 	return type(v) == "table" and v.GetSkillEffect ~= nil
 end
 
+local function skillIndexingFn(self, key)
+	if key == "GetSkillEffect" and self.__Id then
+		local t = skillIndex[self.__Id] or self
+		return t.__GetSkillEffect
+	end
+
+	return self[key]
+end
+
 function modApiExtHooks:overrideAllSkills()
 	if not modApiExt_internal.oldSkills then
 		modApiExt_internal.oldSkills = {}
@@ -493,8 +502,7 @@ function modApiExtHooks:overrideAllSkills()
 				v.__Id = k
 				v.__GetSkillEffect = rawget(v, "GetSkillEffect")
 				skillIndex[k] = setmetatable(
-					{ GetSkillEffect = v.__GetSkillEffect },
-					{ __index = v }
+					{ __index = skillIndexingFn }
 				)
 			end
 		end

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -502,6 +502,7 @@ function modApiExtHooks:overrideAllSkills()
 				v.__Id = k
 				v.__GetSkillEffect = rawget(v, "GetSkillEffect")
 				skillIndex[k] = setmetatable(
+					{},
 					{ __index = skillIndexingFn }
 				)
 			end

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -504,7 +504,7 @@ local function skillProxyNewIndexFn(tbl, key, value)
 	realSkill[key] = value
 end
 
-modApiExt_internal.createSkillProxy(skillTable)
+function modApiExt_internal.createSkillProxy(skillTable)
 	assert(skillTable.__Id ~= nil, "The skillTable must have an `__Id` field that is equal to its identifier in _G")
 	modApiExt_internal.oldSkills[skillTable.__Id] = skillTable
 

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -489,7 +489,7 @@ function modApiExtHooks:overrideAllSkills()
 				v.__Id = k
 				originalSkillsEnv[k] = setmetatable(
 					{ GetSkillEffect = v.GetSkillEffect },
-					{ __index = skill }
+					{ __index = v }
 				)
 			end
 		end

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -481,13 +481,12 @@ local function isSkill(v)
 	return type(v) == "table" and v.GetSkillEffect ~= nil
 end
 
-local function skillIndexingFn(self, key)
-	if key == "GetSkillEffect" and self.__Id then
-		local t = skillIndex[self.__Id] or self
-		return t.__GetSkillEffect
+local function skillIndexingFn(tbl, key)
+	local skill = _G[tbl.id]
+	if key == "GetSkillEffect" then
+		return skill.__GetSkillEffect
 	end
-
-	return self[key]
+	return skill[key] 
 end
 
 function modApiExtHooks:overrideAllSkills()
@@ -502,7 +501,7 @@ function modApiExtHooks:overrideAllSkills()
 				v.__Id = k
 				v.__GetSkillEffect = rawget(v, "GetSkillEffect")
 				skillIndex[k] = setmetatable(
-					{},
+					{ id = k },
 					{ __index = skillIndexingFn }
 				)
 			end

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -395,10 +395,10 @@ local function modApiExtGetSkillEffect(self, p1, p2, ...)
 		self = _G[self]
 	end
 
-	modApiExt_internal.nestedSkillEffectCall = true
+	modApiExt_internal.nestedCall_GetSkillEffect = true
 	local fn = _G[self.__Id].GetSkillEffect
 	local skillFx = fn(self, p1, p2, ...)
-	modApiExt_internal.nestedSkillEffectCall = false
+	modApiExt_internal.nestedCall_GetSkillEffect = false
 
 	if not Pawn then
 		-- PAWN is missing, this happens when loading into a game
@@ -490,7 +490,7 @@ end
 local function skillProxyIndexFn(tbl, key)
 	local realSkill = modApiExt_internal.oldSkills[tbl.id]
 	if key == "GetSkillEffect" then
-		if modApiExt_internal.nestedSkillEffectCall then
+		if modApiExt_internal.nestedCall_GetSkillEffect then
 			return realSkill.GetSkillEffect
 		else
 			return modApiExtGetSkillEffect
@@ -523,7 +523,7 @@ function modApiExtHooks:overrideAllSkills()
 	if not modApiExt_internal.oldSkills then
 		modApiExt_internal.oldSkills = {}
 		modApiExt_internal.skillIndex = setmetatable({}, { __index = _G })
-		modApiExt_internal.nestedSkillEffectCall = false
+		modApiExt_internal.nestedCall_GetSkillEffect = false
 
 		-- do this in two passes, so that for weapon upgrades we don't
 		-- accidentally set their original skill to our override, if we're

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -510,6 +510,10 @@ function modApiExt_internal.createSkillProxy(skillTable)
 	local skillProxy = setmetatable(
 		{
 			__skill = skillTable,
+			-- Duplicate skill functions from the original skill table
+			-- for use cases that need to check if the skill overrides
+			-- a particular function from its parent.
+			__GetSkillEffect = rawget(skillTable, "GetSkillEffect")
 		},
 		{
 			__index = skillProxyIndexFn,

--- a/modApiExt/alter.lua
+++ b/modApiExt/alter.lua
@@ -504,6 +504,9 @@ function modApiExtHooks:overrideAllSkills()
 					{ id = k },
 					{ __index = skillIndexingFn }
 				)
+				-- Make sure to change env of original functions so that they don't
+				-- accidentally invoke modApiExt's override and cause an infinite loop
+				setfenv(v.GetSkillEffect, skillIndex)
 			end
 		end
 		for k, v in pairs(_G) do


### PR DESCRIPTION
Previously, `modApiExtGetSkillEffect` didn't support nested calls to `GetSkillEffect`, eg. this snippet:
```lua
function MySkill:GetSkillEffect(p1, p2)
    return MyOtherSkill.GetSkillEffect(self, p1, p2)
end
```
would end up producing an empty SkillList.

This PR fixes that, while also making skill overriding logic a little bit more straightforward.