### PR TITLE
Update alter.lua

### DIFF
--- a/scripts/alter.lua
+++ b/scripts/alter.lua
@@ -395,6 +395,9 @@ local function modApiExtGetSkillEffect(self, p1, p2, ...)
 		self = _G[self]
 	end
 
+	p1 = p1 or Point(-1,-1)
+	p2 = p2 or Point(-1,-1)
+
 	local pawn = Board:GetPawn(p1)
 	local pawnId = pawn and pawn:GetId() or -1
 
@@ -470,6 +473,10 @@ local function modApiExtGetFinalEffect(self, p1, p2, p3, ...)
 		self = _G[self]
 	end
 
+	p1 = p1 or Point(-1,-1)
+	p2 = p2 or Point(-1,-1)
+	p3 = p3 or Point(-1,-1)
+	
 	local pawn = Board:GetPawn(p1)
 	local pawnId = pawn and pawn:GetId() or -1
 
@@ -534,6 +541,8 @@ local function modApiExtGetTargetArea(self, p, ...)
 		self = _G[self]
 	end
 
+	p = p or Point(-1,-1)
+
 	modApiExt_internal.nestedCall_GetTargetArea = true
 	local fn = _G[self.__Id].GetTargetArea
 	local targetArea = fn(self, p, ...)
@@ -553,6 +562,9 @@ local function modApiExtGetSecondTargetArea(self, p1, p2, ...)
 		self = _G[self]
 	end
 
+	p1 = p1 or Point(-1,-1)
+	p2 = p2 or Point(-1,-1)
+	
 	modApiExt_internal.nestedCall_GetSecondTargetArea = true
 	local fn = _G[self.__Id].GetSecondTargetArea
 	local targetArea = fn(self, p1, p2, ...)


### PR DESCRIPTION
GetTargetArea can be called with no `point` input; protect against that, since `Board:GetPawn()` cannot be called with `nil`. The hooks will set nil `point` inputs to `Point(-1,-1)`, which will result in `pawn` being `nil`. Add similar protection to the GetSkillEffect hooks just in case.

Addresses #16 